### PR TITLE
Fix npm package missing critical directories during installation

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,42 @@
+# Development files
+node_modules/
+*.log
+*.lock
+.git/
+.gitignore
+.env
+.DS_Store
+
+# Test files
+test/
+tests/
+__tests__/
+*.test.js
+*.test.ts
+*.spec.js
+*.spec.ts
+test-*.js
+test-*.sh
+
+# Documentation
+docs/
+*.md
+!README.md
+!commands/*.md
+
+# Development config
+.eslintrc*
+.prettierrc*
+tsconfig.json
+jest.config.js
+
+# Archive files
+ARCHIVED_*
+autopilot-repo/
+
+# Demo files
+demo-*.js
+
+# Package files
+package-*.json
+!package.json

--- a/package.json
+++ b/package.json
@@ -75,8 +75,11 @@
     "bin/",
     "scripts/",
     "templates/",
+    "hooks/",
+    "commands/",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "index.js"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Fixed npm installation failures caused by missing `hooks/` and `commands/` directories
- Added proper file inclusion configuration to ensure all required files are packaged

## Problem
When installing claude-code-autopilot via npm or directly from GitHub, the installation would fail with:
```
ENOENT: no such file or directory, chmod '.../hooks/autopilot-hook.py'
```

This was because the `package.json` `files` array didn't include the `hooks/` and `commands/` directories, which contain critical files needed for AutoPilot to function.

## Solution
1. Updated `package.json` to include:
   - `hooks/` directory (contains autopilot-hook.py)
   - `commands/` directory (contains slash command definitions)
   - `index.js` (main entry point)

2. Created `.npmignore` to:
   - Exclude development/test files from the npm package
   - Preserve command markdown files (`\!commands/*.md`)
   - Keep the package size minimal while including all functional files

## Test plan
- [x] Clone the repository and checkout this branch
- [x] Run `npm pack` to create a tarball
- [x] Install from the tarball in a test project
- [x] Verify all required files are present
- [x] Run the setup command successfully

🤖 Generated with [Claude Code](https://claude.ai/code)